### PR TITLE
🌀 Feature : #23 Button 컴포넌트 구현

### DIFF
--- a/client/.prettierrc
+++ b/client/.prettierrc
@@ -3,7 +3,7 @@
   "singleQuote": true,
   "tabWidth": 2,
   "trailingComma": "all",
-  "printWidth": 120,
+  "printWidth": 100,
   "bracketSpacing": true,
   "arrowParens": "always",
   "endOfLine": "auto",

--- a/client/src/components/Button.tsx
+++ b/client/src/components/Button.tsx
@@ -1,0 +1,36 @@
+import { ReactNode, ButtonHTMLAttributes } from 'react';
+import { cn } from '../utils/cn';
+
+const SIZE_STYLE = {
+  large: 'font-16-m px-[2.2rem] py-[1.2rem]',
+  medium: 'font-14-m px-[2rem] py-[1rem]',
+} as const;
+const VARIANT_STYLE = {
+  white: 'border-gray-3 border-1 text-gray-5 bg-white',
+  primary: 'text-white bg-primary-3',
+} as const;
+
+interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+  size: keyof typeof SIZE_STYLE;
+  variant: keyof typeof VARIANT_STYLE;
+  children: ReactNode;
+}
+
+export default function Button({
+  size,
+  variant,
+  children,
+  className,
+  type = 'button',
+  ...props
+}: ButtonProps) {
+  return (
+    <button
+      type={type}
+      className={cn('rounded-[5rem]', SIZE_STYLE[size], VARIANT_STYLE[variant], className)}
+      {...props}
+    >
+      {children}
+    </button>
+  );
+}

--- a/client/src/styles/tokens/typography.css
+++ b/client/src/styles/tokens/typography.css
@@ -83,9 +83,23 @@
     letter-spacing: 0;
   }
 
+  .font-16-m {
+    font-size: 1.6rem;
+    font-weight: 500;
+    line-height: 1.4;
+    letter-spacing: 0;
+  }
+
   .font-16-r {
     font-size: 1.6rem;
     font-weight: 400;
+    line-height: 1.4;
+    letter-spacing: 0;
+  }
+
+  .font-14-m {
+    font-size: 1.4rem;
+    font-weight: 500;
     line-height: 1.4;
     letter-spacing: 0;
   }


### PR DESCRIPTION
## 🌀 Related Issue

- close #23 

## 💬 Description

Button 컴포넌트를 구현했습니다.

- 버튼 라벨로 텍스트뿐만 아니라 이미지도 받도록 확장될 여지가 있다고 판단하여 children의 타입을 string으로 제한하지 않고 ReactNode로 정의하여 확장성을 고려하였습니다.
- SSOT를 위해 SIZE_STYLE, VARIANT_STYLE을 상수로 정의하고 interface, className에서 가져다 사용하도록 했어요. → 추후 small size, secondary variant 등이 추가될 경우 SIZE_STYLE, VARIANT_STYLE에만 추가해도 size, variant 타입에 자동으로 추가되어 중복 추가의 번거로움을 줄이고 오타 등 실수를 방지할 수 있어요.
- 아직 스타일 상수의 길이가 길지 않기 때문에 이 경우 파일 분리 시 오히려 추후 유지보수가 번거로워진다고 생각하여 같은 파일에 위치시켰습니다.
- 다음의 가이드라인에 따라 ButtonProps 타입은 interface로 정의하였습니다.
> 리액트 커뮤니티와 공식 문서에서는 다음과 같은 가이드를 주로 제시합니다.
> 1. 기본적으로 interface 사용을 먼저 고려하세요.
객체의 구조를 정의할 때는 성능(타입 체크 속도)면에서 interface가 약간 더 유리하며, 확장이 용이합니다.
> 2. 유니온 타입이나 튜플 등이 필요할 때만 type을 쓰세요.
앞서 버튼 컴포넌트에서 만든 variant: 'white' | 'primary' 같은 리터럴 유니온 타입은 type이나 interface 내부에 인라인으로 정의하는 것이 맞습니다.

사용법
```tsx
<Button size="large" variant="primary">인증번호 받기</Button>
<Button size="large" variant="white">인증번호 받기</Button>
<Button size="medium" variant="primary">검색</Button>
<Button size="medium" variant="white">엑셀 다운로드</Button>
```

## 📹 Screenshot

<img width="847" height="968" alt="image" src="https://github.com/user-attachments/assets/edc9ed3e-a0b1-4034-beb5-fd8490284c07" />

## 📑 Notes
