### PR TITLE
🌀 Feature : #27 TextField 컴포넌트 구현

### DIFF
--- a/client/src/components/Button.tsx
+++ b/client/src/components/Button.tsx
@@ -6,8 +6,8 @@ const SIZE_STYLE = {
   medium: 'font-14-m px-[2rem] py-[1rem]',
 } as const;
 const VARIANT_STYLE = {
-  white: 'border-gray-3 border-1 text-gray-5 bg-white',
-  primary: 'text-white bg-primary-3',
+  white: 'border-gray-3 border text-gray-5 bg-white',
+  primary: 'text-white bg-primarsy-3',
 } as const;
 
 interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {

--- a/client/src/components/TextField.tsx
+++ b/client/src/components/TextField.tsx
@@ -1,0 +1,25 @@
+import { InputHTMLAttributes } from 'react';
+import { cn } from '../utils/cn';
+
+const STATUS_STYLE = {
+  default: 'border-gray-2 focus:border-primary-3',
+  error: 'border-error',
+} as const;
+
+interface TextFieldProps extends InputHTMLAttributes<HTMLInputElement> {
+  status?: keyof typeof STATUS_STYLE;
+}
+
+export default function TextField({ status = 'default', className, ...props }: TextFieldProps) {
+  return (
+    <input
+      className={cn(
+        'font-14-r text-gray-6 placeholder:text-gray-4 w-full rounded-[0.8rem] border bg-white p-[1.2rem]',
+        STATUS_STYLE[status],
+        className,
+      )}
+      aria-invalid={status === 'error'}
+      {...props}
+    />
+  );
+}


### PR DESCRIPTION
## 🌀 Related Issue

- close #27 

## 💬 Description

TextField 컴포넌트를 구현했습니다.

- TextField는 default, focus, error의 3가지 상태를 가지며 상태별로 스타일이 상이합니다. 최초엔 focus도 status로 정의하고 props로 focus를 받도록 하였으나, 이 경우 사용부에서 focus 여부를 상태로 관리하고 클릭 핸들러도 따로 정의해야 하며 특히 서비스 특성상 한 페이지에 많은 수의 TextField가 존재하기 때문에 관리 복잡 + 다른 TextField를 선택할 때마다 불필요한 리렌더링이 발생의 문제가 있습니다. 따라서 이를 방지하기 위해 focus: 가상 클래스를 사용하였습니다.
- input 태그는 기본적으로 브라우저가 임의로 지정한 fixed width를 가집니다. TextField는 테이블의 td 내에서 사용되는 경우가 대다수이기 때문에 w-full을 기본 스타일로 지정하였으며 다른 너비 속성 적용이 필요할 경우 className으로 전달할 수 있도록 하였습니다.

사용법
```tsx
<TextField />
<TextField status="default" />
<TextField status="error" placeholder="입력하세요" />
```

## 📹 Screenshot

<img width="847" height="968" alt="image" src="https://github.com/user-attachments/assets/9d7e6e26-c9b8-4589-ab81-78ccfbc0f052" />

## 📑 Notes

추후 해야 할 일
- react-hook-form 사용하게 될 경우 TextField가 ref도 받을 수 있도록 수정 필요