### PR TITLE
🫟 STYLE : #29 스크롤바 커스텀

### DIFF
--- a/client/src/components/TextField.tsx
+++ b/client/src/components/TextField.tsx
@@ -2,7 +2,7 @@ import { InputHTMLAttributes } from 'react';
 import { cn } from '../utils/cn';
 
 const STATUS_STYLE = {
-  default: 'border-gray-2 focus:border-primary-3',
+  default: 'border-gray-2 focus:border-primary-3 transition-colors duration-200 ease-in-out',
   error: 'border-error',
 } as const;
 

--- a/client/src/styles/base.css
+++ b/client/src/styles/base.css
@@ -23,4 +23,19 @@
       Arial,
       sans-serif;
   }
+
+  ::-webkit-scrollbar {
+    width: 8px;
+    height: 8px;
+  }
+
+  ::-webkit-scrollbar-track {
+    background-color: var(--color-gray-1);
+    border-radius: 10rem;
+  }
+
+  ::-webkit-scrollbar-thumb {
+    background-color: var(--color-gray-4);
+    border-radius: 10rem;
+  }
 }


### PR DESCRIPTION
## 🌀 Related Issue

- close #29 

## 💬 Description

스크롤바 커스텀을 진행했습니다.

-webkit-scrollbar, -webkit-scrollbar-track, -webkit-scrollbar-thumb 속성 사용했고 스크롤바가 페이지 단위에서뿐만 아니라 표 내에서도 사용되므로 html, body가 아닌 전역에 적용되도록 하였습니다.

## 📹 Screenshot

<img width="847" height="968" alt="image" src="https://github.com/user-attachments/assets/f6d2aa69-c889-4e11-82d3-dfd1f15c216a" />

## 📑 Notes

조회 페이지의 경우 이중 스크롤바(페이지, 표)가 생길 수 있으며 이 부분에 대해 개선이 필요할 경우 추후 진행 필요