### PR TITLE
♻️ REFACTOR : #39 카카오 로그인 API 리팩토링

### DIFF
--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -12,7 +12,7 @@ const PORT = process.env.PORT || 4000;
 app.use(cors());
 app.use(morgan("dev"));
 app.use(express.json());
-app.use("/auth", authRouter);
+app.use("/api/v1/auth", authRouter);
 
 app.get("/", (req, res) => {
   res.send("서버가 정상적으로 작동 중입니다! 🚀");

--- a/server/src/controllers/auth.controller.ts
+++ b/server/src/controllers/auth.controller.ts
@@ -1,52 +1,40 @@
 import axios from "axios";
-import jwt from "jsonwebtoken";
 import { Request, Response } from "express";
 import { AuthService } from "../services/auth.service.ts";
+import { serializeBigInt } from "../utils/serializeBigInt.ts";
 
 export const AuthController = {
   kakaoLogin: async (req: Request, res: Response) => {
     const { code } = req.query;
-    if (!code) return res.status(400).send("코드가 없습니다.");
+    if (!code) return res.status(400).send("코드가 존재하지 않습니다.");
 
     try {
-      const kakaoToken = await AuthService.getKakaoToken(code as string);
-      const kakaoUser = await AuthService.getKakaoUser(kakaoToken);
+      const kakaoToken = await AuthService.fetchKakaoToken(code);
+      const kakaoUser = await AuthService.fetchKakaoUser(kakaoToken);
+      const { user, accessToken, refreshToken } =
+        await AuthService.kakaoLogin(kakaoUser);
 
-      const accessToken = jwt.sign(
-        { userId: kakaoUser.id.toString() },
-        process.env.JWT_ACCESS_SECRET!,
-        { expiresIn: "1h" },
+      res.json(
+        serializeBigInt({
+          accessToken,
+          refreshToken,
+          userId: user.id,
+          name: user.name,
+          proflie: user.profile_image_url,
+        }),
       );
-
-      const refreshToken = jwt.sign(
-        { userId: kakaoUser.id.toString() },
-        process.env.JWT_REFRESH_SECRET!,
-        { expiresIn: "14d" },
-      );
-
-      const user = await AuthService.upsertKakaoUser(kakaoUser, refreshToken);
-
-      res.json({ accessToken, refreshToken, user: serializeUser(user) });
     } catch (error) {
       if (axios.isAxiosError(error)) {
-        console.error("카카오 에러 응답:", error.response?.data);
+        console.error("카카오 에러 응답 : ", error.response?.data);
         res.status(error.response?.status || 500).json({
           message: "카카오 로그인 통신 오류",
           detail: error.response?.data,
         });
       } else {
         const err = error as Error;
-        console.error("일반 에러:", err.message);
+        console.error("일반 에러 : ", err.message);
         res.status(500).send("서버 내부 오류");
       }
     }
   },
-};
-
-const serializeUser = (user: any) => {
-  return JSON.parse(
-    JSON.stringify(user, (key, value) =>
-      typeof value === "bigint" ? value.toString() : value,
-    ),
-  );
 };

--- a/server/src/services/auth.service.ts
+++ b/server/src/services/auth.service.ts
@@ -1,9 +1,10 @@
 import qs from "qs";
 import axios from "axios";
+import jwt from "jsonwebtoken";
 import prisma from "../lib/prisma.ts";
 
 export const AuthService = {
-  getKakaoToken: async (code: string) => {
+  fetchKakaoToken: async (code: string) => {
     const response = await axios({
       method: "POST",
       url: "https://kauth.kakao.com/oauth/token",
@@ -20,29 +21,47 @@ export const AuthService = {
     return response.data.access_token;
   },
 
-  getKakaoUser: async (kakaoToken: string) => {
+  fetchKakaoUser: async (kakaoToken: string) => {
     const { data } = await axios.get("https://kapi.kakao.com/v2/user/me", {
       headers: { Authorization: `Bearer ${kakaoToken}` },
     });
+
     return data;
   },
 
-  upsertKakaoUser: async (kakaoUser: any, refreshToken: string) => {
-    return await prisma.user.upsert({
+  kakaoLogin: async (kakaoUser: any) => {
+    const user = await prisma.user.upsert({
       where: { kakao_id: kakaoUser.id },
       update: {
         name: kakaoUser.kakao_account?.profile?.nickname,
         profile_image_url:
           kakaoUser.kakao_account?.profile?.thumbnail_image_url,
-        refresh_token: refreshToken,
+        refresh_token: "",
       },
       create: {
         kakao_id: kakaoUser.id,
         name: kakaoUser.kakao_account?.profile?.nickname,
         profile_image_url:
           kakaoUser.kakao_account?.profile?.thumbnail_image_url,
-        refresh_token: refreshToken,
+        refresh_token: "",
       },
     });
+
+    const payload = { userId: user.id.toString() };
+    const accessToken = jwt.sign(payload, process.env.JWT_ACCESS_SECRET!, {
+      expiresIn: "1h",
+    });
+    const refreshToken = jwt.sign(payload, process.env.JWT_ACCESS_SECRET!, {
+      expiresIn: "14d",
+    });
+
+    prisma.user
+      .update({
+        where: { id: user.id },
+        data: { refresh_token: refreshToken },
+      })
+      .catch((error) => console.error("토큰 저장 실패:", error));
+
+    return { user, accessToken, refreshToken };
   },
 };

--- a/server/src/utils/serializeBigInt.ts
+++ b/server/src/utils/serializeBigInt.ts
@@ -1,0 +1,19 @@
+export const serializeBigInt = (data: any): any => {
+  if (data === null || data === undefined) return data;
+
+  if (typeof data === "bigint") {
+    return data.toString();
+  }
+
+  if (Array.isArray(data)) {
+    return data.map(serializeBigInt);
+  }
+
+  if (typeof data === "object") {
+    return Object.fromEntries(
+      Object.entries(data).map(([key, value]) => [key, serializeBigInt(value)]),
+    );
+  }
+
+  return data;
+};


### PR DESCRIPTION
## 🌀 Related Issue

- close #39 

## 💬 Description

카카오 로그인 API 리팩토링을 진행했습니다.

`serializeBigInt 유틸 생성`

기존에는 serializeUser로 auth.service.ts에서 정의, 사용하고 있었으나 공통적으로 사용될 가능성이 높다고 판단하여 공통 유틸로 분리하였습니다.

`엔드포인트 /api/v1으로 시작하도록 변경`

정적 파일 등이 아니라 데이터를 전달하는 api 역할을 함을 명시적으로 나타내기 위해 /api를, 추후 용이한 버전관리를 위해 /v1을 붙이도록 수정하였습니다.

`관심사 분리`

기존에는 controller에 토큰 생성 등 비즈니스 로직이 혼재되어 있다는 문제가 있어 해당 로직을 service로 옮기고, service에서도 카카오 로그인 관련 로직을 모아 kakaoLogin 메서드를 생성하였습니다.

또한 기존에는 jwt에 페이로드로 kakaoId를 전달하던 것을 userId를 전달하도록 변경하였습니다.

## 📹 Screenshot

## 📑 Notes
