### PR TITLE
🌀 FEATURE : #40 인증 미들웨어 구현

### DIFF
--- a/server/src/middleware/auth.middleware.ts
+++ b/server/src/middleware/auth.middleware.ts
@@ -1,0 +1,27 @@
+import jwt from "jsonwebtoken";
+import { Request, Response, NextFunction } from "express";
+
+export const authMiddleware = (
+  req: Request,
+  res: Response,
+  next: NextFunction,
+) => {
+  const accessToken = req.headers.authorization?.split(" ")[1];
+
+  if (!accessToken) {
+    return res.status(401).json({ message: "인증되지 않은 사용자입니다." });
+  }
+
+  try {
+    const decoded = jwt.verify(
+      accessToken,
+      process.env.JWT_ACCESS_SECRET as string,
+    ) as any;
+
+    req.user = { id: BigInt(decoded.userId) };
+
+    next();
+  } catch (error) {
+    return res.status(403).json({ message: "유효하지 않은 토큰입니다." });
+  }
+};

--- a/server/src/types/express.d.ts
+++ b/server/src/types/express.d.ts
@@ -1,0 +1,11 @@
+import * as express from "express";
+
+declare global {
+  namespace Express {
+    interface Request {
+      user: {
+        id: bigint;
+      };
+    }
+  }
+}

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -9,8 +9,9 @@
     "strict": true,
     "skipLibCheck": true,
     "baseUrl": ".",
+    "typeRoots": ["./node_modules/@types", "./src/types"],
     "paths": {
-      "*": ["node_modules/*"]
+      "*": ["node_modules/*", "src/types/*"]
     },
     "noEmit": true,
     "allowImportingTsExtensions": true


### PR DESCRIPTION
## 🌀 Related Issue

- close #40 

## 💬 Description

JUMBLE의 경우 기본적으로 로그인한 사용자를 대상으로 하므로 모든 API 엔드포인트에서 로그인 여부 확인이 필요합니다. 이때 로그인 여부 확인을 개별적으로 수행한다면 코드 중복을 야기하고 유지보수를 어렵게 만들 수 있습니다.

→ 그래서 인증 미들웨어를 도입하였습니다.

미들웨어란 **request가 들어와서 최종 목적지인 controller에 도달하기 전 중간에서 가로채 특정 작업을 수행하는 함수**로, 클라이언트가 요청 헤더에 담아 보낸 AccessToken을 서버의 시크릿 키로 검증하고, 검증 성공 시 요청을 다음 단계(다음 미들웨어/컨트롤러)로 넘기고 실패 시 에러를 전달합니다.

```typescript
import jwt from "jsonwebtoken";
import { Request, Response, NextFunction } from "express";

export const authMiddleware = (
  req: Request,
  res: Response,
  next: NextFunction,
) => {
  const accessToken = req.headers.authorization?.split(" ")[1];

  if (!accessToken) {
    return res.status(401).json({ message: "인증되지 않은 사용자입니다." });
  }

  try {
    const decoded = jwt.verify(
      accessToken,
      process.env.JWT_ACCESS_SECRET as string,
    ) as any;

    req.user = { id: BigInt(decoded.userId) };

    next();
  } catch (error) {
    return res.status(403).json({ message: "유효하지 않은 토큰입니다." });
  }
};

```

또한 로그인 여부를 확인하는 데서 그치지 않고 다음 단계에 사용자 정보를 함께 넘겨주어 다음 미들웨어/컨트롤러에서 사용자 정보를 즉시 사용할 수 있도록 하였습니다. 이 경우 컨트롤러는 별도의 인증 로직 없이 본연의 비즈니스 로직에만 집중할 수 있게 됩니다. 그리고 이를 위해 Express의 기본 Request 타입에 user 필드를 추가하였습니다!

## 📹 Screenshot

## 📑 Notes
