### PR TITLE
🌀 FEATURE : #42 사입내역 추가 API 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules/
 dist/
 .DS_Store
 .env
+CLAUDE.md

--- a/server/prisma/migrations/20260323135437_refactor/migration.sql
+++ b/server/prisma/migrations/20260323135437_refactor/migration.sql
@@ -1,0 +1,45 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `ocr_status` on the `receipts` table. All the data in the column will be lost.
+  - A unique constraint covering the columns `[purchase_item_no]` on the table `purchase_items` will be added. If there are existing duplicate values, this will fail.
+  - A unique constraint covering the columns `[purchase_no]` on the table `purchases` will be added. If there are existing duplicate values, this will fail.
+  - A unique constraint covering the columns `[purchase_id]` on the table `receipts` will be added. If there are existing duplicate values, this will fail.
+  - Made the column `purchase_item_no` on table `purchase_items` required. This step will fail if there are existing NULL values in that column.
+  - Made the column `category` on table `purchase_items` required. This step will fail if there are existing NULL values in that column.
+  - Made the column `backorder_quantity` on table `purchase_items` required. This step will fail if there are existing NULL values in that column.
+  - Made the column `created_at` on table `purchase_items` required. This step will fail if there are existing NULL values in that column.
+  - Made the column `created_at` on table `purchases` required. This step will fail if there are existing NULL values in that column.
+  - Made the column `created_at` on table `receipts` required. This step will fail if there are existing NULL values in that column.
+  - Made the column `created_at` on table `users` required. This step will fail if there are existing NULL values in that column.
+  - Made the column `created_at` on table `vendors` required. This step will fail if there are existing NULL values in that column.
+
+*/
+-- AlterTable
+ALTER TABLE `purchase_items` MODIFY `purchase_item_no` VARCHAR(50) NOT NULL,
+    MODIFY `category` ENUM('TOP', 'OUTER', 'BOTTOM', 'SET', 'BAG', 'SHOES', 'JEWELRY', 'ACCESSORY', 'ETC') NOT NULL,
+    MODIFY `backorder_quantity` INTEGER NOT NULL DEFAULT 0,
+    MODIFY `created_at` DATETIME(0) NOT NULL DEFAULT CURRENT_TIMESTAMP(0);
+
+-- AlterTable
+ALTER TABLE `purchases` MODIFY `created_at` DATETIME(0) NOT NULL DEFAULT CURRENT_TIMESTAMP(0);
+
+-- AlterTable
+ALTER TABLE `receipts` DROP COLUMN `ocr_status`,
+    MODIFY `created_at` DATETIME(0) NOT NULL DEFAULT CURRENT_TIMESTAMP(0);
+
+-- AlterTable
+ALTER TABLE `users` ADD COLUMN `refresh_token` VARCHAR(1000) NULL,
+    MODIFY `created_at` DATETIME(0) NOT NULL DEFAULT CURRENT_TIMESTAMP(0);
+
+-- AlterTable
+ALTER TABLE `vendors` MODIFY `created_at` DATETIME(0) NOT NULL DEFAULT CURRENT_TIMESTAMP(0);
+
+-- CreateIndex
+CREATE UNIQUE INDEX `purchase_items_purchase_item_no_key` ON `purchase_items`(`purchase_item_no`);
+
+-- CreateIndex
+CREATE UNIQUE INDEX `purchases_purchase_no_key` ON `purchases`(`purchase_no`);
+
+-- CreateIndex
+CREATE UNIQUE INDEX `receipts_purchase_id_key` ON `receipts`(`purchase_id`);

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -18,7 +18,7 @@ model User {
   name              String?    @db.VarChar(255)
   profile_image_url String?    @db.VarChar(1000)
   refresh_token     String?    @db.VarChar(1000)
-  created_at        DateTime?  @default(now()) @db.DateTime(0)
+  created_at        DateTime   @default(now()) @db.DateTime(0)
   
   vendors           Vendor[]
   purchases         Purchase[]
@@ -30,7 +30,7 @@ model Vendor {
   id         BigInt     @id @default(autoincrement())
   user_id    BigInt
   name       String     @db.VarChar(255)
-  created_at DateTime?  @default(now()) @db.DateTime(0)
+  created_at DateTime   @default(now()) @db.DateTime(0)
   
   user       User       @relation(fields: [user_id], references: [id], onDelete: Cascade)
   purchases  Purchase[]
@@ -43,14 +43,14 @@ model Purchase {
   id          BigInt         @id @default(autoincrement())
   user_id     BigInt
   vendor_id   BigInt
-  purchase_no String         @db.VarChar(50)
+  purchase_no String         @unique @db.VarChar(50)
   purchased_at DateTime      @db.DateTime(0)
-  created_at  DateTime?      @default(now()) @db.DateTime(0)
+  created_at  DateTime       @default(now()) @db.DateTime(0)
   
   user        User           @relation(fields: [user_id], references: [id], onDelete: Cascade)
   vendor      Vendor         @relation(fields: [vendor_id], references: [id], onDelete: Restrict)
   items       PurchaseItem[]
-  receipts    Receipt[]
+  receipt     Receipt?
 
   @@index([user_id, purchased_at], map: "idx_purchases_user_date")
   @@index([vendor_id], map: "idx_purchases_vendor")
@@ -60,16 +60,16 @@ model Purchase {
 model PurchaseItem {
   id                 BigInt    @id @default(autoincrement())
   purchase_id        BigInt
-  purchase_item_no   String?   @db.VarChar(50)
+  purchase_item_no   String    @unique @db.VarChar(50)
   item_name          String    @db.VarChar(255)
-  category           String?   @db.VarChar(100)
+  category           Category
   color              String?   @db.VarChar(100)
   size               String?   @db.VarChar(50)
   extra_option       String?   @db.VarChar(255)
   unit_price         Int
   quantity           Int
-  backorder_quantity Int?      @default(0)
-  created_at         DateTime? @default(now()) @db.DateTime(0)
+  backorder_quantity Int       @default(0)
+  created_at         DateTime  @default(now()) @db.DateTime(0)
   
   purchase           Purchase  @relation(fields: [purchase_id], references: [id], onDelete: Cascade)
 
@@ -80,13 +80,24 @@ model PurchaseItem {
 
 model Receipt {
   id                BigInt    @id @default(autoincrement())
-  purchase_id       BigInt
+  purchase_id       BigInt    @unique
   receipt_image_url String    @db.VarChar(1000)
-  ocr_status        String?   @default("PENDING") @db.VarChar(50)
-  created_at        DateTime? @default(now()) @db.DateTime(0)
+  created_at        DateTime  @default(now()) @db.DateTime(0)
   
   purchase          Purchase  @relation(fields: [purchase_id], references: [id], onDelete: Cascade)
 
   @@index([purchase_id], map: "fk_receipts_purchase")
   @@map("receipts")
+}
+
+enum Category {
+  TOP
+  OUTER
+  BOTTOM
+  SET
+  BAG
+  SHOES
+  JEWELRY
+  ACCESSORY
+  ETC
 }

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -3,6 +3,7 @@ import morgan from "morgan";
 import dotenv from "dotenv";
 import express from "express";
 import authRouter from "./routes/auth.routes.js";
+import purchaseRouter from "./routes/purchase.routes.ts";
 
 dotenv.config();
 
@@ -13,6 +14,7 @@ app.use(cors());
 app.use(morgan("dev"));
 app.use(express.json());
 app.use("/api/v1/auth", authRouter);
+app.use("/api/v1/purchases", purchaseRouter);
 
 app.get("/", (req, res) => {
   res.send("서버가 정상적으로 작동 중입니다! 🚀");

--- a/server/src/controllers/purchase.controller.ts
+++ b/server/src/controllers/purchase.controller.ts
@@ -1,0 +1,101 @@
+import { Request, Response } from "express";
+import { Prisma, Category } from "@prisma/client";
+import { CreatePurchaseDto } from "../types/purchase.ts";
+import { PurchaseService } from "../services/purchase.service.ts";
+
+const VALID_CATEGORIES = Object.values(Category);
+
+export const PurchaseController = {
+  createPurchase: async (req: Request, res: Response) => {
+    try {
+      const data: CreatePurchaseDto = req.body;
+      const userId = req.user.id;
+
+      // 필수 필드 검증
+      if (!data.vendorName || !data.purchasedDate || !data.receipt) {
+        return res.status(400).json({
+          success: false,
+          status: 400,
+          message: "vendorName, purchasedDate, receipt는 필수 값입니다.",
+        });
+      }
+
+      // items 검증
+      if (!Array.isArray(data.items) || data.items.length === 0) {
+        return res.status(400).json({
+          success: false,
+          status: 400,
+          message: "items는 1개 이상이어야 합니다.",
+        });
+      }
+
+      // items 내 필수 필드 및 category enum 검증
+      for (const item of data.items) {
+        if (
+          !item.productName ||
+          item.unitPrice == null ||
+          item.quantity == null
+        ) {
+          return res.status(400).json({
+            success: false,
+            status: 400,
+            message:
+              "각 item에 productName, unitPrice, quantity는 필수 값입니다.",
+          });
+        }
+
+        if (!VALID_CATEGORIES.includes(item.category)) {
+          return res.status(400).json({
+            success: false,
+            status: 400,
+            message: `category는 다음 값 중 하나여야 합니다: ${VALID_CATEGORIES.join(", ")}`,
+          });
+        }
+      }
+
+      const newPurchaseId = await PurchaseService.createPurchase(userId, data);
+
+      return res.status(201).json({
+        success: true,
+        status: 201,
+        message: "사입내역 추가에 성공했습니다.",
+        id: newPurchaseId,
+      });
+    } catch (error) {
+      console.error("🚨 서버 에러 발생:", error);
+
+      if (error instanceof Prisma.PrismaClientKnownRequestError) {
+        // 외래키 제약 위반
+        if (error.code === "P2003") {
+          return res.status(400).json({
+            success: false,
+            status: 400,
+            message: "유효하지 않은 참조 값입니다.",
+          });
+        }
+        // 유니크 제약 위반
+        if (error.code === "P2002") {
+          return res.status(409).json({
+            success: false,
+            status: 409,
+            message: "이미 존재하는 데이터입니다.",
+          });
+        }
+      }
+
+      if (error instanceof Prisma.PrismaClientValidationError) {
+        return res.status(400).json({
+          success: false,
+          status: 400,
+          message: "요청 데이터 형식이 올바르지 않습니다.",
+        });
+      }
+
+      return res.status(500).json({
+        success: false,
+        status: 500,
+        message: "서버 오류가 발생했습니다.",
+      });
+    }
+  },
+};

--- a/server/src/routes/purchase.routes.ts
+++ b/server/src/routes/purchase.routes.ts
@@ -1,0 +1,9 @@
+import express, { Router } from "express";
+import { authMiddleware } from "../middleware/auth.middleware.ts";
+import { PurchaseController } from "../controllers/purchase.controller.ts";
+
+const router: Router = express.Router();
+
+router.post("/", authMiddleware, PurchaseController.createPurchase);
+
+export default router;

--- a/server/src/services/purchase.service.ts
+++ b/server/src/services/purchase.service.ts
@@ -1,0 +1,57 @@
+import prisma from "../lib/prisma.ts";
+import { serializeBigInt } from "../utils/serializeBigInt.ts";
+import { CreatePurchaseDto, CreatePurchaseItemDto } from "../types/purchase.ts";
+
+export const PurchaseService = {
+  createPurchase: async (userId: bigint, data: CreatePurchaseDto) => {
+    return await prisma.$transaction(async (tx) => {
+      let vendor = await tx.vendor.findFirst({
+        where: {
+          user_id: userId,
+          name: data.vendorName,
+        },
+      });
+
+      if (!vendor) {
+        vendor = await tx.vendor.create({
+          data: {
+            user_id: userId,
+            name: data.vendorName,
+          },
+        });
+      }
+
+      const newPurchase = await tx.purchase.create({
+        data: {
+          user_id: userId,
+          vendor_id: vendor.id,
+          purchase_no: Date.now().toString(),
+          purchased_at: new Date(data.purchasedDate),
+          items: {
+            create: data.items.map((item: CreatePurchaseItemDto, idx) => ({
+              purchase_item_no: `${Date.now()}${idx + 1}`,
+              item_name: item.productName,
+              category: item.category,
+              color: item.color,
+              size: item.size,
+              extra_option: item.extraOption,
+              unit_price: item.unitPrice,
+              quantity: item.quantity,
+              backorder_quantity: item.backorderQuantity,
+            })),
+          },
+          receipt: {
+            create: {
+              receipt_image_url: data.receipt,
+            },
+          },
+        },
+        select: {
+          id: true,
+        },
+      });
+
+      return serializeBigInt(newPurchase.id);
+    });
+  },
+};

--- a/server/src/types/purchase.ts
+++ b/server/src/types/purchase.ts
@@ -1,0 +1,19 @@
+import { Category } from "@prisma/client";
+
+export interface CreatePurchaseItemDto {
+  productName: string;
+  category: Category;
+  color?: string;
+  size?: string;
+  extraOption?: string;
+  unitPrice: number;
+  quantity: number;
+  backorderQuantity?: number;
+}
+
+export interface CreatePurchaseDto {
+  vendorName: string;
+  purchasedDate: string;
+  receipt: string;
+  items: CreatePurchaseItemDto[];
+}


### PR DESCRIPTION
## 🌀 Related Issue

- close #42 

## 💬 Description

`purchase.service.ts`

- vendor를 upsert 방식으로 처리합니다. 동일 사용자 + 동일 이름의 vendor가 이미 존재하면 재사용하고, 없으면 새로 생성합니다.
- vendor 조회/생성 → purchase 생성 → items 생성 → receipt 생성 전 과정을 하나의 트랜잭션으로 묶었습니다. 중간에 실패하더라도 부분 데이터가 DB에 남지 않도록 합니다.
- 응답으로 돌려주는 id는 DB의 BigInt 타입인데, JSON.stringify가 BigInt를 직렬화하지 못하므로 serializeBigInt 유틸을 통해 string으로 변환 후 반환합니다.

`types/purchase.ts`

- 요청 body의 타입을 CreatePurchaseDto, CreatePurchaseItemDto로 명시적으로 정의했습니다. controller와 service 전반에서 any 없이 타입 안전하게 데이터를 다룰 수 있습니다.

## 📹 Screenshot

## 📑 Notes
