### PR TITLE
🌀 FEATURE : #45 사입내역 조회 API 구현

### DIFF
--- a/server/src/controllers/purchase.controller.ts
+++ b/server/src/controllers/purchase.controller.ts
@@ -53,13 +53,13 @@ export const PurchaseController = {
         }
       }
 
-      const newPurchaseId = await PurchaseService.createPurchase(userId, data);
+      const newPurchase = await PurchaseService.createPurchase(userId, data);
 
       return res.status(201).json({
         success: true,
         status: 201,
         message: "사입내역 추가에 성공했습니다.",
-        id: newPurchaseId,
+        id: newPurchase.id,
       });
     } catch (error) {
       console.error("🚨 서버 에러 발생:", error);
@@ -81,6 +81,44 @@ export const PurchaseController = {
             message: "이미 존재하는 데이터입니다.",
           });
         }
+      }
+
+      if (error instanceof Prisma.PrismaClientValidationError) {
+        return res.status(400).json({
+          success: false,
+          status: 400,
+          message: "요청 데이터 형식이 올바르지 않습니다.",
+        });
+      }
+
+      return res.status(500).json({
+        success: false,
+        status: 500,
+        message: "서버 오류가 발생했습니다.",
+      });
+    }
+  },
+
+  getPurchases: async (req: Request, res: Response) => {
+    try {
+      const userId = req.user.id;
+      const purchases = await PurchaseService.getPurchases(userId);
+
+      return res.status(200).json({
+        success: true,
+        status: 200,
+        message: "사입내역 조회에 성공했습니다.",
+        purchases,
+      });
+    } catch (error) {
+      console.error("🚨 서버 에러 발생:", error);
+
+      if (error instanceof Prisma.PrismaClientKnownRequestError) {
+        return res.status(400).json({
+          success: false,
+          status: 400,
+          message: "잘못된 요청입니다.",
+        });
       }
 
       if (error instanceof Prisma.PrismaClientValidationError) {

--- a/server/src/controllers/purchase.controller.ts
+++ b/server/src/controllers/purchase.controller.ts
@@ -102,13 +102,34 @@ export const PurchaseController = {
   getPurchases: async (req: Request, res: Response) => {
     try {
       const userId = req.user.id;
-      const purchases = await PurchaseService.getPurchases(userId);
+      const page = parseInt(req.query.page as string) || 1;
+      const limit = parseInt(req.query.limit as string) || 10;
+
+      if (page < 1 || limit < 1) {
+        return res.status(400).json({
+          success: false,
+          status: 400,
+          message: "page와 limit은 1 이상이어야 합니다.",
+        });
+      }
+
+      const { purchases, total } = await PurchaseService.getPurchases(
+        userId,
+        page,
+        limit,
+      );
 
       return res.status(200).json({
         success: true,
         status: 200,
         message: "사입내역 조회에 성공했습니다.",
         purchases,
+        pagination: {
+          total,
+          page,
+          limit,
+          totalPages: Math.ceil(total / limit),
+        },
       });
     } catch (error) {
       console.error("🚨 서버 에러 발생:", error);

--- a/server/src/routes/purchase.routes.ts
+++ b/server/src/routes/purchase.routes.ts
@@ -5,5 +5,6 @@ import { PurchaseController } from "../controllers/purchase.controller.ts";
 const router: Router = express.Router();
 
 router.post("/", authMiddleware, PurchaseController.createPurchase);
+router.get("/", authMiddleware, PurchaseController.getPurchases);
 
 export default router;

--- a/server/src/services/purchase.service.ts
+++ b/server/src/services/purchase.service.ts
@@ -55,34 +55,42 @@ export const PurchaseService = {
     });
   },
 
-  getPurchases: async (userId: bigint) => {
-    const purchases = await prisma.purchase.findMany({
-      where: { user_id: userId },
-      select: {
-        id: true,
-        purchase_no: true,
-        purchased_at: true,
-        created_at: true,
-        vendor: { select: { name: true } },
-        items: {
-          select: {
-            id: true,
-            purchase_item_no: true,
-            item_name: true,
-            category: true,
-            color: true,
-            size: true,
-            extra_option: true,
-            unit_price: true,
-            quantity: true,
-            backorder_quantity: true,
-            created_at: true,
+  getPurchases: async (userId: bigint, page: number, limit: number) => {
+    const skip = (page - 1) * limit;
+    const where = { user_id: userId };
+
+    const [purchases, total] = await prisma.$transaction([
+      prisma.purchase.findMany({
+        where,
+        skip,
+        take: limit,
+        orderBy: { purchased_at: "desc" },
+        select: {
+          id: true,
+          purchase_no: true,
+          purchased_at: true,
+          created_at: true,
+          vendor: { select: { name: true } },
+          items: {
+            select: {
+              id: true,
+              purchase_item_no: true,
+              item_name: true,
+              category: true,
+              color: true,
+              size: true,
+              extra_option: true,
+              unit_price: true,
+              quantity: true,
+              backorder_quantity: true,
+              created_at: true,
+            },
           },
+          receipt: { select: { receipt_image_url: true } },
         },
-        receipt: { select: { receipt_image_url: true } },
-      },
-      orderBy: { purchased_at: "desc" },
-    });
+      }),
+      prisma.purchase.count({ where }),
+    ]);
 
     const formattedPurchases = purchases.map(
       ({
@@ -122,6 +130,6 @@ export const PurchaseService = {
       }),
     );
 
-    return serializeBigInt(formattedPurchases);
+    return { purchases: serializeBigInt(formattedPurchases), total };
   },
 };

--- a/server/src/services/purchase.service.ts
+++ b/server/src/services/purchase.service.ts
@@ -51,7 +51,77 @@ export const PurchaseService = {
         },
       });
 
-      return serializeBigInt(newPurchase.id);
+      return serializeBigInt(newPurchase);
     });
+  },
+
+  getPurchases: async (userId: bigint) => {
+    const purchases = await prisma.purchase.findMany({
+      where: { user_id: userId },
+      select: {
+        id: true,
+        purchase_no: true,
+        purchased_at: true,
+        created_at: true,
+        vendor: { select: { name: true } },
+        items: {
+          select: {
+            id: true,
+            purchase_item_no: true,
+            item_name: true,
+            category: true,
+            color: true,
+            size: true,
+            extra_option: true,
+            unit_price: true,
+            quantity: true,
+            backorder_quantity: true,
+            created_at: true,
+          },
+        },
+        receipt: { select: { receipt_image_url: true } },
+      },
+      orderBy: { purchased_at: "desc" },
+    });
+
+    const formattedPurchases = purchases.map(
+      ({
+        vendor,
+        receipt,
+        purchase_no,
+        purchased_at,
+        created_at,
+        items,
+        ...purchase
+      }) => ({
+        ...purchase,
+        purchaseNo: purchase_no,
+        purchasedAt: purchased_at,
+        createdAt: created_at,
+        vendor: vendor.name,
+        receipt: receipt?.receipt_image_url ?? null,
+        items: items.map(
+          ({
+            purchase_item_no,
+            item_name,
+            extra_option,
+            unit_price,
+            backorder_quantity,
+            created_at: itemCreatedAt,
+            ...item
+          }) => ({
+            ...item,
+            purchaseItemNo: purchase_item_no,
+            itemName: item_name,
+            extraOption: extra_option,
+            unitPrice: unit_price,
+            backorderQuantity: backorder_quantity,
+            createdAt: itemCreatedAt,
+          }),
+        ),
+      }),
+    );
+
+    return serializeBigInt(formattedPurchases);
   },
 };

--- a/server/src/utils/serializeBigInt.ts
+++ b/server/src/utils/serializeBigInt.ts
@@ -9,6 +9,10 @@ export const serializeBigInt = (data: any): any => {
     return data.map(serializeBigInt);
   }
 
+  if (data instanceof Date) {
+    return data.toISOString();
+  }
+
   if (typeof data === "object") {
     return Object.fromEntries(
       Object.entries(data).map(([key, value]) => [key, serializeBigInt(value)]),


### PR DESCRIPTION
## 🌀 Related Issue

- close #45 

## 💬 Description

`변경 사항`

- purchase.routes.ts — GET / 라우트 추가
- purchase.controller.ts — getPurchases 핸들러 추가
- purchase.service.ts — getPurchases 비즈니스 로직 추가
- utils/serializeBigInt.ts — Date 객체 직렬화 버그 수정

`핵심 로직 및 설계 이유`

<p>1. userId는 request body가 아닌 auth 미들웨어에서 취득</p>

req.user.id를 사용합니다. 인증된 사용자 본인의 데이터만 조회하는 구조이므로, 클라이언트에서 별도로 userId를 전달받을 필요가 없습니다.

<p>2. select로 필요한 필드만 명시적으로 조회</p>

include 대신 select를 사용해 응답에 불필요한 user_id, vendor_id, purchase_id 등을 DB 조회 단계에서부터 제외했습니다.

<p>3. 중첩 관계 데이터를 1depth로 flatten</p>

vendor.name, receipt.receipt_image_url을 각각 vendor, receipt 문자열 필드로 변환해 응답 구조를 단순하게 유지했습니다. 프론트에서 중첩 객체를 탐색하지 않아도 됩니다.

<p>4. snake_case → camelCase 변환</p>

DB 컬럼명은 snake_case이나 JSON API 응답은 JS/TS 관례에 따라 camelCase로 내려주는 것이 표준이므로 service의 매핑 단계에서 일괄 변환합니다. (purchase_no → purchaseNo, purchased_at → purchasedAt 등)

<p>5. Date 객체 직렬화 버그 수정</p>

기존 serializeBigInt 유틸이 Date 객체를 일반 object로 처리해 {}로 직렬화되는 문제가 존재해 instanceof Date 체크를 추가해 toISOString()으로 변환하도록 수정했습니다.

<p>6. 최신순 정렬</p>

orderBy: { purchased_at: "desc" }로 가장 최근 사입내역이 먼저 오도록 정렬했습니다.

## 📹 Screenshot

## 📑 Notes
