### PR TITLE
🌀 FEATURE : #47 사입내역 상세 조회 API 구현

### DIFF
--- a/server/src/controllers/purchase.controller.ts
+++ b/server/src/controllers/purchase.controller.ts
@@ -157,4 +157,44 @@ export const PurchaseController = {
       });
     }
   },
+
+  getPurchase: async (req: Request, res: Response) => {
+    try {
+      const userId = req.user.id;
+      const purchaseId = BigInt(req.params.id as string);
+
+      const purchase = await PurchaseService.getPurchase(userId, purchaseId);
+
+      if (!purchase) {
+        return res.status(404).json({
+          success: false,
+          status: 404,
+          message: "사입내역을 찾을 수 없습니다.",
+        });
+      }
+
+      return res.status(200).json({
+        success: true,
+        status: 200,
+        message: "사입내역 상세 조회에 성공했습니다.",
+        purchase,
+      });
+    } catch (error) {
+      console.error("🚨 서버 에러 발생:", error);
+
+      if (error instanceof Prisma.PrismaClientKnownRequestError) {
+        return res.status(400).json({
+          success: false,
+          status: 400,
+          message: "잘못된 요청입니다.",
+        });
+      }
+
+      return res.status(500).json({
+        success: false,
+        status: 500,
+        message: "서버 오류가 발생했습니다.",
+      });
+    }
+  },
 };

--- a/server/src/routes/purchase.routes.ts
+++ b/server/src/routes/purchase.routes.ts
@@ -6,5 +6,6 @@ const router: Router = express.Router();
 
 router.post("/", authMiddleware, PurchaseController.createPurchase);
 router.get("/", authMiddleware, PurchaseController.getPurchases);
+router.get("/:id", authMiddleware, PurchaseController.getPurchase);
 
 export default router;

--- a/server/src/services/purchase.service.ts
+++ b/server/src/services/purchase.service.ts
@@ -132,4 +132,63 @@ export const PurchaseService = {
 
     return { purchases: serializeBigInt(formattedPurchases), total };
   },
+
+  getPurchase: async (userId: bigint, purchaseId: bigint) => {
+    const purchase = await prisma.purchase.findFirst({
+      where: { id: purchaseId, user_id: userId },
+      select: {
+        id: true,
+        purchase_no: true,
+        purchased_at: true,
+        vendor: { select: { name: true } },
+        items: {
+          select: {
+            id: true,
+            purchase_item_no: true,
+            item_name: true,
+            category: true,
+            color: true,
+            size: true,
+            extra_option: true,
+            unit_price: true,
+            quantity: true,
+            backorder_quantity: true,
+          },
+        },
+        receipt: { select: { receipt_image_url: true } },
+      },
+    });
+
+    if (!purchase) return null;
+
+    const { vendor, receipt, purchase_no, purchased_at, items, ...rest } =
+      purchase;
+
+    const formattedPurchase = {
+      ...rest,
+      purchaseNo: purchase_no,
+      purchasedAt: purchased_at,
+      vendor: vendor.name,
+      receipt: receipt?.receipt_image_url ?? null,
+      items: items.map(
+        ({
+          purchase_item_no,
+          item_name,
+          extra_option,
+          unit_price,
+          backorder_quantity,
+          ...item
+        }) => ({
+          ...item,
+          purchaseItemNo: purchase_item_no,
+          itemName: item_name,
+          extraOption: extra_option,
+          unitPrice: unit_price,
+          backorderQuantity: backorder_quantity,
+        }),
+      ),
+    };
+
+    return serializeBigInt(formattedPurchase);
+  },
 };


### PR DESCRIPTION
## 🌀 Related Issue

- close #47 

## 💬 Description

`변경 사항`
- purchase.routes.ts — GET /:id 라우트 추가
- purchase.controller.ts — getPurchase 핸들러 추가
- purchase.service.ts — getPurchase 비즈니스 로직 추가

`핵심 로직 및 설계 이유`

<p>1. findUnique 대신 findFirst 사용</p>

where 조건으로 id와 user_id를 함께 사용합니다. findUnique는 단일 unique 필드 또는 복합 unique 조건만 허용하는데, id + user_id 조합은 스키마에 복합 unique 제약이 없으므로 findFirst가 적합합니다.

<p>2. user_id 조건을 where에 포함</p>

id만으로 조회하면 다른 사용자의 사입내역도 접근할 수 있습니다. user_id: userId 조건을 함께 걸어 본인 데이터만 조회되도록 했습니다. 결과가 null이면 존재하지 않거나 권한이 없는 경우로 보고 404를 반환합니다.

<p>3. req.params.id를 BigInt로 변환</p>

URL path parameter는 Express에서 string으로 전달됩니다. DB의 id는 bigint 타입이므로 BigInt() 변환이 필요합니다. Express의 타입 정의상 params는 string | string[]으로 추론되어 as string 캐스팅을 사용했습니다. path parameter는 항상 단일 string이므로 안전합니다.

<p>4. 응답 구조를 전체 조회 API와 동일하게 유지</p>

camelCase 변환, vendor/receipt flattening 등 getPurchases와 동일한 포맷을 적용했습니다. 프론트에서 목록과 상세 응답을 동일한 타입으로 처리할 수 있습니다.

## 📹 Screenshot

## 📑 Notes
