### PR TITLE
🌀 FEATURE : #48 상품사입내역 상세 조회 API 구현

### DIFF
--- a/server/src/controllers/purchase.controller.ts
+++ b/server/src/controllers/purchase.controller.ts
@@ -197,4 +197,44 @@ export const PurchaseController = {
       });
     }
   },
+
+  getPurchaseItem: async (req: Request, res: Response) => {
+    try {
+      const userId = req.user.id;
+      const itemId = BigInt(req.params.itemId as string);
+
+      const item = await PurchaseService.getPurchaseItem(userId, itemId);
+
+      if (!item) {
+        return res.status(404).json({
+          success: false,
+          status: 404,
+          message: "상품 사입내역을 찾을 수 없습니다.",
+        });
+      }
+
+      return res.status(200).json({
+        success: true,
+        status: 200,
+        message: "상품 사입내역 상세 조회에 성공했습니다.",
+        item,
+      });
+    } catch (error) {
+      console.error("🚨 서버 에러 발생:", error);
+
+      if (error instanceof Prisma.PrismaClientKnownRequestError) {
+        return res.status(400).json({
+          success: false,
+          status: 400,
+          message: "잘못된 요청입니다.",
+        });
+      }
+
+      return res.status(500).json({
+        success: false,
+        status: 500,
+        message: "서버 오류가 발생했습니다.",
+      });
+    }
+  },
 };

--- a/server/src/controllers/purchase.controller.ts
+++ b/server/src/controllers/purchase.controller.ts
@@ -161,8 +161,17 @@ export const PurchaseController = {
   getPurchase: async (req: Request, res: Response) => {
     try {
       const userId = req.user.id;
-      const purchaseId = BigInt(req.params.id as string);
+      const rawPurchaseId = req.params.id as string;
 
+      if (!/^\d+$/.test(rawPurchaseId)) {
+        return res.status(400).json({
+          success: false,
+          status: 400,
+          message: "id는 정수여야 합니다.",
+        });
+      }
+
+      const purchaseId = BigInt(rawPurchaseId);
       const purchase = await PurchaseService.getPurchase(userId, purchaseId);
 
       if (!purchase) {
@@ -201,8 +210,17 @@ export const PurchaseController = {
   getPurchaseItem: async (req: Request, res: Response) => {
     try {
       const userId = req.user.id;
-      const itemId = BigInt(req.params.itemId as string);
+      const rawItemId = req.params.itemId as string;
 
+      if (!/^\d+$/.test(rawItemId)) {
+        return res.status(400).json({
+          success: false,
+          status: 400,
+          message: "itemId는 정수여야 합니다.",
+        });
+      }
+
+      const itemId = BigInt(rawItemId);
       const item = await PurchaseService.getPurchaseItem(userId, itemId);
 
       if (!item) {

--- a/server/src/routes/purchase.routes.ts
+++ b/server/src/routes/purchase.routes.ts
@@ -6,6 +6,7 @@ const router: Router = express.Router();
 
 router.post("/", authMiddleware, PurchaseController.createPurchase);
 router.get("/", authMiddleware, PurchaseController.getPurchases);
+router.get("/items/:itemId", authMiddleware, PurchaseController.getPurchaseItem);
 router.get("/:id", authMiddleware, PurchaseController.getPurchase);
 
 export default router;

--- a/server/src/services/purchase.service.ts
+++ b/server/src/services/purchase.service.ts
@@ -1,4 +1,5 @@
 import prisma from "../lib/prisma.ts";
+import { formatPurchaseItem } from "../utils/format.ts";
 import { serializeBigInt } from "../utils/serializeBigInt.ts";
 import { CreatePurchaseDto, CreatePurchaseItemDto } from "../types/purchase.ts";
 
@@ -108,25 +109,10 @@ export const PurchaseService = {
         createdAt: created_at,
         vendor: vendor.name,
         receipt: receipt?.receipt_image_url ?? null,
-        items: items.map(
-          ({
-            purchase_item_no,
-            item_name,
-            extra_option,
-            unit_price,
-            backorder_quantity,
-            created_at: itemCreatedAt,
-            ...item
-          }) => ({
-            ...item,
-            purchaseItemNo: purchase_item_no,
-            itemName: item_name,
-            extraOption: extra_option,
-            unitPrice: unit_price,
-            backorderQuantity: backorder_quantity,
-            createdAt: itemCreatedAt,
-          }),
-        ),
+        items: items.map(({ created_at, ...item }) => ({
+          ...formatPurchaseItem(item),
+          createdAt: created_at,
+        })),
       }),
     );
 
@@ -170,23 +156,7 @@ export const PurchaseService = {
       purchasedAt: purchased_at,
       vendor: vendor.name,
       receipt: receipt?.receipt_image_url ?? null,
-      items: items.map(
-        ({
-          purchase_item_no,
-          item_name,
-          extra_option,
-          unit_price,
-          backorder_quantity,
-          ...item
-        }) => ({
-          ...item,
-          purchaseItemNo: purchase_item_no,
-          itemName: item_name,
-          extraOption: extra_option,
-          unitPrice: unit_price,
-          backorderQuantity: backorder_quantity,
-        }),
-      ),
+      items: items.map(formatPurchaseItem),
     };
 
     return serializeBigInt(formattedPurchase);

--- a/server/src/services/purchase.service.ts
+++ b/server/src/services/purchase.service.ts
@@ -1,5 +1,5 @@
 import prisma from "../lib/prisma.ts";
-import { formatPurchaseItem } from "../utils/format.ts";
+import { formatPurchase, formatPurchaseItem } from "../utils/format.ts";
 import { serializeBigInt } from "../utils/serializeBigInt.ts";
 import { CreatePurchaseDto, CreatePurchaseItemDto } from "../types/purchase.ts";
 
@@ -70,7 +70,6 @@ export const PurchaseService = {
           id: true,
           purchase_no: true,
           purchased_at: true,
-          created_at: true,
           vendor: { select: { name: true } },
           items: {
             select: {
@@ -84,7 +83,6 @@ export const PurchaseService = {
               unit_price: true,
               quantity: true,
               backorder_quantity: true,
-              created_at: true,
             },
           },
           receipt: { select: { receipt_image_url: true } },
@@ -93,28 +91,7 @@ export const PurchaseService = {
       prisma.purchase.count({ where }),
     ]);
 
-    const formattedPurchases = purchases.map(
-      ({
-        vendor,
-        receipt,
-        purchase_no,
-        purchased_at,
-        created_at,
-        items,
-        ...purchase
-      }) => ({
-        ...purchase,
-        purchaseNo: purchase_no,
-        purchasedAt: purchased_at,
-        createdAt: created_at,
-        vendor: vendor.name,
-        receipt: receipt?.receipt_image_url ?? null,
-        items: items.map(({ created_at, ...item }) => ({
-          ...formatPurchaseItem(item),
-          createdAt: created_at,
-        })),
-      }),
-    );
+    const formattedPurchases = purchases.map(formatPurchase);
 
     return { purchases: serializeBigInt(formattedPurchases), total };
   },
@@ -147,19 +124,7 @@ export const PurchaseService = {
 
     if (!purchase) return null;
 
-    const { vendor, receipt, purchase_no, purchased_at, items, ...rest } =
-      purchase;
-
-    const formattedPurchase = {
-      ...rest,
-      purchaseNo: purchase_no,
-      purchasedAt: purchased_at,
-      vendor: vendor.name,
-      receipt: receipt?.receipt_image_url ?? null,
-      items: items.map(formatPurchaseItem),
-    };
-
-    return serializeBigInt(formattedPurchase);
+    return serializeBigInt(formatPurchase(purchase));
   },
 
   getPurchaseItem: async (userId: bigint, itemId: bigint) => {

--- a/server/src/services/purchase.service.ts
+++ b/server/src/services/purchase.service.ts
@@ -161,4 +161,29 @@ export const PurchaseService = {
 
     return serializeBigInt(formattedPurchase);
   },
+
+  getPurchaseItem: async (userId: bigint, itemId: bigint) => {
+    const item = await prisma.purchaseItem.findFirst({
+      where: {
+        id: itemId,
+        purchase: { user_id: userId },
+      },
+      select: {
+        id: true,
+        purchase_item_no: true,
+        item_name: true,
+        category: true,
+        color: true,
+        size: true,
+        extra_option: true,
+        unit_price: true,
+        quantity: true,
+        backorder_quantity: true,
+      },
+    });
+
+    if (!item) return null;
+
+    return serializeBigInt(formatPurchaseItem(item));
+  },
 };

--- a/server/src/utils/format.ts
+++ b/server/src/utils/format.ts
@@ -1,0 +1,22 @@
+export const formatPurchaseItem = ({
+  purchase_item_no,
+  item_name,
+  extra_option,
+  unit_price,
+  backorder_quantity,
+  ...rest
+}: {
+  purchase_item_no: string;
+  item_name: string;
+  extra_option: string | null;
+  unit_price: number;
+  backorder_quantity: number;
+  [key: string]: unknown;
+}) => ({
+  ...rest,
+  purchaseItemNo: purchase_item_no,
+  itemName: item_name,
+  extraOption: extra_option,
+  unitPrice: unit_price,
+  backorderQuantity: backorder_quantity,
+});

--- a/server/src/utils/format.ts
+++ b/server/src/utils/format.ts
@@ -20,3 +20,26 @@ export const formatPurchaseItem = ({
   unitPrice: unit_price,
   backorderQuantity: backorder_quantity,
 });
+
+export const formatPurchase = ({
+  purchase_no,
+  purchased_at,
+  vendor,
+  receipt,
+  items,
+  ...rest
+}: {
+  purchase_no: string;
+  purchased_at: Date;
+  vendor: { name: string };
+  receipt: { receipt_image_url: string } | null | undefined;
+  items: Parameters<typeof formatPurchaseItem>[0][];
+  [key: string]: unknown;
+}) => ({
+  ...rest,
+  purchaseNo: purchase_no,
+  purchasedAt: purchased_at,
+  vendor: vendor.name,
+  receipt: receipt?.receipt_image_url ?? null,
+  items: items.map(formatPurchaseItem),
+});


### PR DESCRIPTION
## 🌀 Related Issue

- close #48 

## 💬 Description

`변경 파일`

- purchase.routes.ts — GET /items/:itemId 라우트 추가
- purchase.controller.ts — getPurchaseItem 핸들러 추가
- purchase.service.ts — getPurchaseItem 비즈니스 로직 추가, formatPurchaseItem 헬퍼 분리
- utils/format.ts — formatPurchaseItem 유틸 함수 신규 생성

`핵심 로직 및 설계 이유`

<p>1. 기존 purchase 파일에 추가 (파일 분리 없음)</p>

purchase_items는 purchases의 하위 리소스이므로 별도 파일로 분리하지 않고 기존 파일에 추가했습니다.

<p>2. 라우트 순서: /items/:itemId를 /:id 앞에 등록</p>

Express는 라우트를 등록 순서대로 매칭합니다. /:id를 먼저 등록하면 /purchases/items/5 요청에서 items가 id 파라미터로 인식됩니다.  /items/:itemId를 /:id 앞에 등록하여 이를 방지했습니다.

<p>3. purchase 조인으로 소유권 검증</p>

where: { id: itemId, purchase: { user_id: userId } } 조건으로 단일 쿼리에서 조회와 소유권 검증을 동시에 처리했습니다. 별도의 검증 쿼리 없이 결과가 null이면 존재하지 않거나 접근 권한이 없는 경우로 처리합니다.

<p>4. formatPurchaseItem 헬퍼 추출</p>

getPurchases, getPurchase, getPurchaseItem 세 곳에 동일한 snake_case → camelCase 변환 로직이 반복되고 있었습니다. utils/format.ts로 추출하여 중복을 제거하고, 필드명 매핑이 변경될 때 한 곳만 수정하면 되도록 개선했습니다.

## 📹 Screenshot

## 📑 Notes
