### PR TITLE
🌀 FEATURE : #50 영수증 조회 API 구현

### DIFF
--- a/server/src/controllers/purchase.controller.ts
+++ b/server/src/controllers/purchase.controller.ts
@@ -207,6 +207,55 @@ export const PurchaseController = {
     }
   },
 
+  getPurchaseReceipt: async (req: Request, res: Response) => {
+    try {
+      const userId = req.user.id;
+      const rawPurchaseId = req.params.id as string;
+
+      if (!/^\d+$/.test(rawPurchaseId)) {
+        return res.status(400).json({
+          success: false,
+          status: 400,
+          message: "id는 정수여야 합니다.",
+        });
+      }
+
+      const purchaseId = BigInt(rawPurchaseId);
+      const receipt = await PurchaseService.getPurchaseReceipt(userId, purchaseId);
+
+      if (!receipt) {
+        return res.status(404).json({
+          success: false,
+          status: 404,
+          message: "사입내역을 찾을 수 없습니다.",
+        });
+      }
+
+      return res.status(200).json({
+        success: true,
+        status: 200,
+        message: "영수증 조회에 성공했습니다.",
+        ...receipt,
+      });
+    } catch (error) {
+      console.error("🚨 서버 에러 발생:", error);
+
+      if (error instanceof Prisma.PrismaClientKnownRequestError) {
+        return res.status(400).json({
+          success: false,
+          status: 400,
+          message: "잘못된 요청입니다.",
+        });
+      }
+
+      return res.status(500).json({
+        success: false,
+        status: 500,
+        message: "서버 오류가 발생했습니다.",
+      });
+    }
+  },
+
   getPurchaseItem: async (req: Request, res: Response) => {
     try {
       const userId = req.user.id;

--- a/server/src/routes/purchase.routes.ts
+++ b/server/src/routes/purchase.routes.ts
@@ -7,6 +7,7 @@ const router: Router = express.Router();
 router.post("/", authMiddleware, PurchaseController.createPurchase);
 router.get("/", authMiddleware, PurchaseController.getPurchases);
 router.get("/items/:itemId", authMiddleware, PurchaseController.getPurchaseItem);
+router.get("/:id/receipt", authMiddleware, PurchaseController.getPurchaseReceipt);
 router.get("/:id", authMiddleware, PurchaseController.getPurchase);
 
 export default router;

--- a/server/src/services/purchase.service.ts
+++ b/server/src/services/purchase.service.ts
@@ -127,6 +127,25 @@ export const PurchaseService = {
     return serializeBigInt(formatPurchase(purchase));
   },
 
+  getPurchaseReceipt: async (userId: bigint, purchaseId: bigint) => {
+    const purchase = await prisma.purchase.findFirst({
+      where: { id: purchaseId, user_id: userId },
+      select: {
+        id: true,
+        purchase_no: true,
+        receipt: { select: { receipt_image_url: true } },
+      },
+    });
+
+    if (!purchase) return null;
+
+    return serializeBigInt({
+      id: purchase.id,
+      purchaseNo: purchase.purchase_no,
+      receipt: purchase.receipt?.receipt_image_url ?? null,
+    });
+  },
+
   getPurchaseItem: async (userId: bigint, itemId: bigint) => {
     const item = await prisma.purchaseItem.findFirst({
       where: {


### PR DESCRIPTION
## 🌀 Related Issue

- close #50 

## 💬 Description

영수증 조회 API 구현을 진행했습니다.

### 변경 파일

- `server/src/services/purchase.service.ts` — `getPurchaseReceipt` 서비스 메서드 추가
- `server/src/controllers/purchase.controller.ts` — `getPurchaseReceipt` 컨트롤러 추가
- `server/src/routes/purchase.routes.ts` — 라우트 등록

### 주요 내용

1. `GET /:id/receipt` — 서브리소스 URL 구조 채택
영수증은 사입내역(`purchase`)에 종속된 리소스이므로, `/purchases/:id/receipt`처럼 중첩 경로로 표현하는 것이 REST 원칙에 부합합니다. 별도의 `/receipts/:id` 엔드포인트로 분리하면 클라이언트가 `receipt_id`를 별도로 알아야 하는 불필요한 의존성이 생깁니다.

2. 라우트 등록 순서 — `/:id/receipt`를 `/:id` 앞에 배치
Express는 라우트를 등록 순서대로 매칭합니다. `/:id/receipt`를 `/:id` 뒤에 두면 Express가 `receipt`를 `:id` 파라미터 값으로 인식해 `getPurchase`로 잘못 라우팅됩니다. 의도한 컨트롤러가 실행되도록 구체적인 경로를 먼저 등록했습니다.

3. `id` 파라미터 정수 검증 (`!/^\d+$/`)
`BigInt()`는 숫자가 아닌 문자열 입력 시 런타임 에러를 throw합니다. 정규식으로 사전 검증해 예측 가능한 400 응답을 반환하고, 의도치 않은 500 에러를 방지했습니다.

4. `select`로 필요한 필드만 조회
`purchase_no`, `receipt.receipt_image_url`, `id` 세 필드만 select해불필요한 컬럼만 조회하도록 했습니다.

5. `serializeBigInt` 적용
`id` 필드가 Prisma에서 `BigInt`로 매핑되므로, `JSON.stringify` 직렬화 시 에러가 발생합니다. 다른 서비스 메서드와 동일하게 `serializeBigInt`로 감싸 일관성을 유지했습니다.

6. `receipt`가 `null`일 수 있는 케이스 처리
`receipt`는 `purchase`와 1:1 관계지만 optional 이므로 `null`일 수 있습니다. `receipt?.receipt_image_url ?? null`로 null-safe하게 처리해 런타임 에러를 방지했습니다.

## 📹 Screenshot

## 📑 Notes
