### PR TITLE
🌀 FEAT : #69 RefreshToken 재발급 API 구현 및 연동

### DIFF
--- a/client/src/lib/api.ts
+++ b/client/src/lib/api.ts
@@ -1,0 +1,32 @@
+async function reissue() {
+  const res = await fetch(`${import.meta.env.VITE_API_URL}/api/v1/auth/refresh`);
+  const { accessToken, refreshToken } = await res.json();
+
+  localStorage.setItem('accessToken', accessToken);
+  localStorage.setItem('refreshToken', refreshToken);
+}
+
+export async function fetchWithAuth(url: string, options: RequestInit) {
+  const accessToken = localStorage.getItem('accessToken');
+
+  let res = await fetch(url, {
+    ...options,
+    headers: {
+      ...options.headers,
+      Authorization: `Bearer ${accessToken}`,
+    },
+  });
+
+  if (res.status === 401) {
+    await reissue();
+    res = await fetch(url, {
+      ...options,
+      headers: {
+        ...options.headers,
+        Authorization: `Bearer ${accessToken}`,
+      },
+    });
+  }
+
+  return res;
+}

--- a/client/src/pages/purchases/new/apis/index.ts
+++ b/client/src/pages/purchases/new/apis/index.ts
@@ -1,6 +1,7 @@
 import { UseFormSetValue, UseFieldArrayReplace } from 'react-hook-form';
 import { useMutation } from '@tanstack/react-query';
 import { Purchase } from '@jumble/shared';
+import { fetchWithAuth } from '@/lib/api';
 
 const compressImage = (file: File, maxWidth = 1024): Promise<Blob> => {
   return new Promise((resolve) => {
@@ -26,7 +27,7 @@ const parseImage = async (file: File) => {
   const formData = new FormData();
   formData.append('image', compressed, 'receipt.jpg');
 
-  const res = await fetch(`${import.meta.env.VITE_API_URL}/api/v1/ocr/parse`, {
+  const res = await fetchWithAuth(`${import.meta.env.VITE_API_URL}/api/v1/ocr/parse`, {
     method: 'POST',
     body: formData,
   });

--- a/server/src/auth/auth.controller.ts
+++ b/server/src/auth/auth.controller.ts
@@ -6,7 +6,10 @@ import { serializeBigInt } from '../utils/serializeBigInt';
 export const AuthController = {
   kakaoLogin: async (req: Request, res: Response) => {
     const { code } = req.query;
-    if (!code || typeof code !== 'string') return res.status(400).send('코드가 존재하지 않습니다.');
+
+    if (!code || typeof code !== 'string') {
+      return res.status(400).send('코드가 존재하지 않습니다.');
+    }
 
     try {
       const kakaoToken = await AuthService.fetchKakaoToken(code);
@@ -30,10 +33,25 @@ export const AuthController = {
           detail: error.response?.data,
         });
       } else {
-        const err = error as Error;
-        console.error('일반 에러 : ', err.message);
+        console.error((error as Error).message);
         res.status(500).send('서버 내부 오류');
       }
+    }
+  },
+
+  reissue: async (req: Request, res: Response) => {
+    const { refreshToken } = req.body;
+
+    if (!refreshToken) {
+      return res.status(400).json({ message: 'refreshToken이 없습니다.' });
+    }
+
+    try {
+      const token = await AuthService.reissue(refreshToken);
+      res.json(token);
+    } catch (error) {
+      console.error((error as Error).message);
+      res.status(401).json({ message: '유효하지 않은 토큰입니다.' });
     }
   },
 };

--- a/server/src/auth/auth.routes.ts
+++ b/server/src/auth/auth.routes.ts
@@ -7,7 +7,7 @@ router.get('/kakao', (req: Request, res: Response) => {
   const kakaoAuthUrl = `https://kauth.kakao.com/oauth/authorize?client_id=${process.env.KAKAO_REST_API_KEY}&redirect_uri=${process.env.KAKAO_REDIRECT_URI}&response_type=code`;
   res.redirect(kakaoAuthUrl);
 });
-
 router.get('/kakao/callback', AuthController.kakaoLogin);
+router.get('/refresh', AuthController.reissue);
 
 export default router;

--- a/server/src/auth/auth.service.ts
+++ b/server/src/auth/auth.service.ts
@@ -49,7 +49,7 @@ export const AuthService = {
     const accessToken = jwt.sign(payload, process.env.JWT_ACCESS_SECRET!, {
       expiresIn: '1h',
     });
-    const refreshToken = jwt.sign(payload, process.env.JWT_ACCESS_SECRET!, {
+    const refreshToken = jwt.sign(payload, process.env.JWT_REFRESH_SECRET!, {
       expiresIn: '14d',
     });
 
@@ -61,5 +61,30 @@ export const AuthService = {
       .catch((error) => console.error('토큰 저장 실패:', error));
 
     return { user, accessToken, refreshToken };
+  },
+
+  reissue: async (refreshToken: string) => {
+    const decoded = jwt.verify(refreshToken, process.env.JWT_REFRESH_SECRET!) as { userId: string };
+
+    const user = await prisma.user.findUnique({
+      where: { id: BigInt(decoded.userId) },
+    });
+
+    if (!user || user.refresh_token !== refreshToken) {
+      throw new Error('유효하지 않은 토큰입니다.');
+    }
+
+    const payload = { userId: user.id.toString() };
+    const newAccessToken = jwt.sign(payload, process.env.JWT_ACCESS_SECRET!, { expiresIn: '1h' });
+    const newRefreshToken = jwt.sign(payload, process.env.JWT_REFRESH_SECRET!, {
+      expiresIn: '14d',
+    });
+
+    await prisma.user.update({
+      where: { id: user.id },
+      data: { refresh_token: newRefreshToken },
+    });
+
+    return { accessToken: newAccessToken, refreshToken: newRefreshToken };
   },
 };

--- a/server/src/middleware/auth.middleware.ts
+++ b/server/src/middleware/auth.middleware.ts
@@ -15,6 +15,9 @@ export const authMiddleware = (req: Request, res: Response, next: NextFunction) 
 
     next();
   } catch (error) {
+    if (error instanceof jwt.TokenExpiredError) {
+      return res.status(401).json({ message: '토큰이 만료되었습니다.' });
+    }
     return res.status(403).json({ message: '유효하지 않은 토큰입니다.' });
   }
 };


### PR DESCRIPTION
## 🌀 Related Issue

- close #69 

## 💬 Description

### 전체 플로우

```
클라이언트 API 요청 (fetchWithAuth)
  → localStorage에서 accessToken 읽어 Authorization: Bearer {accessToken} 헤더 포함
  → 서버 authMiddleware: jwt.verify()로 토큰 검증
      → 만료된 경우: TokenExpiredError 감지 → 401 응답
      → 위변조된 경우: 403 응답
  → fetchWithAuth: 401 감지 → reissue() 호출
      → GET /api/v1/auth/refresh
      → 서버 AuthController.reissue: req.body에서 refreshToken 추출
      → AuthService.reissue:
          1. jwt.verify()로 refreshToken 유효성 검증
          2. prisma.user.findUnique()로 유저 조회
          3. user.refresh_token과 요청 토큰 일치 여부 비교 (rotation 보안)
          4. jwt.sign()으로 새 accessToken(1h) + refreshToken(14d) 발급
          5. prisma.user.update()로 DB의 refresh_token 갱신
      → 클라이언트 reissue(): 새 토큰 쌍 localStorage에 저장
  → fetchWithAuth: 갱신된 accessToken으로 원래 요청 재시도
```

### 구현 상세

#### 서버: `GET /api/v1/auth/refresh`

refreshToken 재발급 시 **rotation**을 적용했습니다. 요청마다 refreshToken도 함께 교체하고 DB에 갱신된 값을 저장해, 탈취된 구 토큰으로 재발급을 시도하면 DB 값과 불일치로 차단됩니다.

#### 서버: `authMiddleware` 에러 분리

기존에는 만료된 토큰과 위변조된 토큰 모두 403을 반환했습니다. 클라이언트의 자동 갱신 트리거를 401 기준으로 설계했기 때문에, `TokenExpiredError`는 401, 그 외 JWT 오류는 403으로 분리했습니다.

- **401** → 만료 → 클라이언트가 refresh 후 재시도
- **403** → 위변조 → refresh 없이 에러 그대로 반환

#### 클라이언트: `fetchWithAuth`

인증이 필요한 API마다 토큰을 붙이고 만료 처리를 하면 중복이 생기기 때문에, 공통 래퍼 `fetchWithAuth`를 `client/src/lib/api.ts`에 만들었습니다. 앞으로 인증이 필요한 모든 API 호출은 `fetch` 대신 이 함수를 사용합니다.

### 변경 파일

- `server/src/auth/auth.service.ts` — `reissue` 구현, `kakaoLogin` 시크릿 버그 수정
- `server/src/auth/auth.controller.ts` — `reissue` 컨트롤러 추가
- `server/src/auth/auth.routes.ts` — `GET /refresh` 라우트 추가
- `server/src/middleware/auth.middleware.ts` — 만료/위변조 에러 코드 분리
- `client/src/lib/api.ts` — `fetchWithAuth` 구현
- `client/src/pages/purchases/new/apis/index.ts` — `fetchWithAuth` 적용

#### + 추후 변경사항 https://github.com/sminha/JUMBLE/pull/74/changes/0171843fe375543eacde921d0be3876e45decd23

## 📹 Screenshot

## 📑 Notes
